### PR TITLE
List of Available Dates Produced

### DIFF
--- a/FixtureScheduler/BusinessLogic/ApplicationSettings.cs
+++ b/FixtureScheduler/BusinessLogic/ApplicationSettings.cs
@@ -15,22 +15,12 @@ namespace BusinessLogic
             //Teams received via dependency injection
             _teams = teams;
 
-            try
-            {
-                //Attempt to load the settings from the Settings.json file
-                //They will also be checked to see if they are valid
-                Settings = LoadSettings();
+            //Attempt to load the settings from the Settings.json file
+            //They will also be checked to see if they are valid
+            Settings = LoadSettings();
 
-                //The number of rounds needed is calculated using the teams
-                Settings.NumberOfRoundsNeeded = (_teams.Count() - 1) * 2;
-            }
-            catch (FixtureSchedulerException ex)
-            {
-                //Either the Settings.json file wasn't found or it failed validation
-                //Exit the program at this point as the settings are required to continue
-                Console.WriteLine(ex.Message);
-                Environment.Exit(1);
-            }
+            //The number of rounds needed is calculated using the teams
+            Settings.NumberOfRoundsNeeded = (_teams.Count() - 1) * 2;
         }
 
         /// <summary>

--- a/FixtureScheduler/BusinessLogic/ApplicationSettings.cs
+++ b/FixtureScheduler/BusinessLogic/ApplicationSettings.cs
@@ -40,7 +40,13 @@ namespace BusinessLogic
                         StartDate = DateTime.ParseExact(settingsDTO.StartDate, "dd/MM/yyyy", CultureInfo.InvariantCulture),
                         EndDate = DateTime.ParseExact(settingsDTO.EndDate, "dd/MM/yyyy", CultureInfo.InvariantCulture),
                         PrimaryMatchDay = (DayOfWeek)Enum.Parse(typeof(DayOfWeek), settingsDTO.PrimaryMatchday, true),
-                        AlternativeMatchday = (DayOfWeek)Enum.Parse(typeof(DayOfWeek), settingsDTO.AlternativeMatchday, true)
+                        AlternativeMatchday = (DayOfWeek)Enum.Parse(typeof(DayOfWeek), settingsDTO.AlternativeMatchday, true),
+                        ExcludedDates = settingsDTO.ExcludedDates
+                            .Select(dto => new Models.ExcludedDates
+                            {
+                                Date = DateTime.ParseExact(dto.Date, "dd/MM/yyyy", CultureInfo.InvariantCulture),
+                                Reason = dto.Reason
+                            }).ToList()
                     };
                 }
 

--- a/FixtureScheduler/BusinessLogic/Dates.cs
+++ b/FixtureScheduler/BusinessLogic/Dates.cs
@@ -4,27 +4,21 @@ namespace BusinessLogic
 {
     public class Dates : Interfaces.IDates
     {
-        private readonly Models.Settings _settings;
+        private readonly Interfaces.IApplicationSettings _applicationSettings;
         private readonly Interfaces.IBankHolidays _bankHolidays;
+        private List<Models.BankHolidayEvent>? BankHolidays { get; set; }
 
-        public DateTime StartDate { get; private set; }
-        public DateTime EndDate { get; private set; }
-        public DayOfWeek PrimaryMatchDay { get; private set; }
-        public DayOfWeek AlternativeMatchDay { get; private set; }
-        public List<Models.BankHolidayEvent>? BankHolidays { get; private set; }
-
-        public Dates(Models.Settings settings, Interfaces.IBankHolidays bankHolidays)
+        public Dates(Interfaces.IApplicationSettings applicationSettings, Interfaces.IBankHolidays bankHolidays)
         {
-            _settings = settings;
+            //Application settings instance is passed in via dependency injection
+            _applicationSettings = applicationSettings;
+
+            //Bank holidays instance is passed in via dependency injection
             _bankHolidays = bankHolidays;
 
-            this.StartDate = _settings.StartDate;
-            this.EndDate = _settings.EndDate;
-            this.PrimaryMatchDay = _settings.PrimaryMatchDay;
-            this.AlternativeMatchDay = _settings.AlternativeMatchday;
-
             //Gets bank holidays between the supplied dates
-            this.BankHolidays = _bankHolidays.GetBankHolidays(_settings.StartDate, _settings.EndDate);
+            this.BankHolidays = _bankHolidays.GetBankHolidays(_applicationSettings.Settings.StartDate,
+                _applicationSettings.Settings.EndDate);
         }
 
         /// <summary>
@@ -40,14 +34,14 @@ namespace BusinessLogic
             availableDates = AddBankHolidayDates(availableDates);
 
             //Sets the current date variable to the start date
-            var currentDate = this.StartDate;
+            var currentDate = _applicationSettings.Settings.StartDate;
             
             //Keep looping while the current date is less than or equal to the end date
-            while (currentDate <= this.EndDate)
+            while (currentDate <= _applicationSettings.Settings.EndDate)
             {
                 //Checks if the current date's day of the week is equal to the primary matchday and the current 
                 //date is not equal to any of the dates in the excluded dates list
-                if (currentDate.DayOfWeek == this.PrimaryMatchDay && !_settings.ExcludedDates.Any(x => x.Date == currentDate))
+                if (currentDate.DayOfWeek == _applicationSettings.Settings.PrimaryMatchDay && !_applicationSettings.Settings.ExcludedDates.Any(x => x.Date == currentDate))
                 {
                     //Checks to make sure that there isn't already a date in the list
                     //which is within 1 day in either direction
@@ -58,7 +52,7 @@ namespace BusinessLogic
                         availableDates.Add(new Models.AvailableDates
                         {
                             Date = currentDate,
-                            IsPrimaryMatchday = (currentDate.DayOfWeek == this.PrimaryMatchDay) ? true : false
+                            IsPrimaryMatchday = (currentDate.DayOfWeek == _applicationSettings.Settings.PrimaryMatchDay) ? true : false
                         });
                     }
                 }
@@ -81,7 +75,7 @@ namespace BusinessLogic
             {
                 foreach (var bankHoliday in this.BankHolidays)
                 {
-                    if (!_settings.ExcludedDates.Any(x => x.Date == bankHoliday.Date))
+                    if (!_applicationSettings.Settings.ExcludedDates.Any(x => x.Date == bankHoliday.Date))
                     {
                         //Checks to make sure that there isn't already a date in the list
                         //which is within 1 day in either direction
@@ -91,7 +85,7 @@ namespace BusinessLogic
                             listOfAvailableDates.Add(new Models.AvailableDates
                             {
                                 Date = bankHoliday.Date,
-                                IsPrimaryMatchday = (bankHoliday.Date.DayOfWeek == this.PrimaryMatchDay) ? true : false
+                                IsPrimaryMatchday = (bankHoliday.Date.DayOfWeek == _applicationSettings.Settings.PrimaryMatchDay) ? true : false
                             });
                         }
                     }
@@ -112,20 +106,20 @@ namespace BusinessLogic
             var count = 0;
 
             //Sets a variable to the start date - this is used to advance the loop below
-            var currentDate = this.StartDate;
+            var currentDate = _applicationSettings.Settings.StartDate;
 
             //Keeps loop over the dates until the end date is reached
-            while (currentDate <= this.EndDate)
+            while (currentDate <= _applicationSettings.Settings.EndDate)
             {
                 //If the current day in the loop matches either the alternative or primary matchday
                 //the count is increased by one
-                if (currentDate.DayOfWeek == ((useAlternativeMatchday) ? this.AlternativeMatchDay : this.PrimaryMatchDay))
+                if (currentDate.DayOfWeek == ((useAlternativeMatchday) ? _applicationSettings.Settings.AlternativeMatchday : _applicationSettings.Settings.PrimaryMatchDay))
                 {
                     count = count + 1;
                     Console.WriteLine(
                         currentDate.ToString("dd/MM/yyyy") + " is a " +
-                        ((useAlternativeMatchday) ? this.AlternativeMatchDay.ToString() : this.PrimaryMatchDay.ToString())
-                        );
+                        ((useAlternativeMatchday) ? _applicationSettings.Settings.AlternativeMatchday.ToString() : _applicationSettings.Settings.PrimaryMatchDay.ToString())
+                    );
                 }
 
                 //Adds one day to the current date to advance the loop

--- a/FixtureScheduler/BusinessLogic/Teams.cs
+++ b/FixtureScheduler/BusinessLogic/Teams.cs
@@ -1,0 +1,84 @@
+using Microsoft.Extensions.Configuration;
+
+namespace BusinessLogic
+{
+    public class Teams
+    {
+        /// <summary>
+        /// Loads teams from the Settings/Teams.json file
+        /// </summary>
+        /// <returns></returns>
+        public static List<Models.Teams> LoadTeams()
+        {
+            try
+            {
+                var exePath = AppContext.BaseDirectory;
+
+                //Loads the teams json file
+                var config = new ConfigurationBuilder()
+                    .SetBasePath(exePath)
+                    .AddJsonFile("Settings/Teams.json", optional: false, reloadOnChange: false)
+                    .Build();
+
+                //Bind the json to the teams dto
+                List<DTOs.TeamsDTO> teamsDTO = config.GetSection("Teams")
+                    .Get<List<DTOs.TeamsDTO>>()!;
+
+                //Validates the teams using fluent validation
+                var valid = IsValid(teamsDTO);
+
+                if (valid)
+                {
+                    //Convert to a list of teams model and return
+                    return teamsDTO.Select(dto => new Models.Teams
+                    {
+                        Name = dto.Name
+                    }).ToList();
+                }
+
+                //Throw an exception if the teams file failed validation checks
+                throw new FixtureSchedulerException("The Teams.json file wasn't valid. Please check the errors.");
+            }
+            catch (FileNotFoundException)
+            {
+                //Throw an exception if the file can't be found
+                throw new FixtureSchedulerException("Unable to find the Teams.json file in the Settings folder.");
+            }
+        }
+        
+        /// <summary>
+        /// Validates the teams
+        /// </summary>
+        /// <param name="teamsDTO"></param>
+        /// <returns></returns>
+        private static bool IsValid(List<DTOs.TeamsDTO> teamsDTO)
+        {
+            var allValid = true;
+
+            //Creates the fluent validator
+            var validator = new Validation.TeamsValidation();
+
+            //Loops over team in the dto
+            foreach (var team in teamsDTO)
+            {
+                //Validates the team
+                var validationResults = validator.Validate(team);
+
+                //if the validation fails then the error results are returned to the user
+                if (!validationResults.IsValid)
+                {
+                    //Validation has failed - set the allValid variable to false
+                    //and display each of the error messages from the validator
+                    allValid = false;
+                    foreach (var error in validationResults.Errors)
+                    {
+                        Console.WriteLine(error.PropertyName + ":" + error.ErrorMessage);
+                    }
+                }
+            }
+
+            //Returns true or false based on the validation
+            return allValid;
+        }
+    }
+}

--- a/FixtureScheduler/DTOs/ApplicationSettingsDTO.cs
+++ b/FixtureScheduler/DTOs/ApplicationSettingsDTO.cs
@@ -6,5 +6,12 @@ namespace DTOs
         public string EndDate { get; set; } = string.Empty;
         public string PrimaryMatchday { get; set; } = string.Empty;
         public string AlternativeMatchday { get; set; } = string.Empty;
+        public List<ExcludedDatesDTO> ExcludedDates { get; set; } = new List<ExcludedDatesDTO>();
+    }
+
+    public class ExcludedDatesDTO
+    {
+        public string Date { get; set; } = string.Empty;
+        public string Reason { get; set; } = string.Empty;
     }
 }

--- a/FixtureScheduler/DTOs/TeamsDTO.cs
+++ b/FixtureScheduler/DTOs/TeamsDTO.cs
@@ -1,0 +1,7 @@
+namespace DTOs
+{
+    public class TeamsDTO
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+}

--- a/FixtureScheduler/FixtureScheduler.csproj
+++ b/FixtureScheduler/FixtureScheduler.csproj
@@ -18,6 +18,10 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </None>
+    <None Update="Settings\Teams.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/FixtureScheduler/FixtureSchedulerException.cs
+++ b/FixtureScheduler/FixtureSchedulerException.cs
@@ -1,0 +1,5 @@
+public class FixtureSchedulerException : Exception
+{
+    public FixtureSchedulerException(string message)
+            : base(message) { }
+}

--- a/FixtureScheduler/Interfaces/IApplicationSettings.cs
+++ b/FixtureScheduler/Interfaces/IApplicationSettings.cs
@@ -1,0 +1,7 @@
+namespace Interfaces
+{
+    public interface IApplicationSettings
+    {
+        Models.Settings Settings { get; }
+    }
+}

--- a/FixtureScheduler/Interfaces/IDates.cs
+++ b/FixtureScheduler/Interfaces/IDates.cs
@@ -2,12 +2,6 @@ namespace Interfaces
 {
     public interface IDates
     {
-        DateTime StartDate { get; }
-        DateTime EndDate { get; }
-        DayOfWeek PrimaryMatchDay { get; }
-        DayOfWeek AlternativeMatchDay { get; }
-        List<Models.BankHolidayEvent>? BankHolidays { get; }
-
         List<Models.AvailableDates> GetAvailableDates();
 
         int CountMatchdays(bool useAlternativeMatchday = false);

--- a/FixtureScheduler/Interfaces/IDates.cs
+++ b/FixtureScheduler/Interfaces/IDates.cs
@@ -8,6 +8,8 @@ namespace Interfaces
         DayOfWeek AlternativeMatchDay { get; }
         List<Models.BankHolidayEvent>? BankHolidays { get; }
 
+        List<Models.AvailableDates> GetAvailableDates();
+
         int CountMatchdays(bool useAlternativeMatchday = false);
     }
 }

--- a/FixtureScheduler/Models/AvailableDate.cs
+++ b/FixtureScheduler/Models/AvailableDate.cs
@@ -1,0 +1,8 @@
+namespace Models
+{
+    public class AvailableDates
+    {
+        public DateTime Date { get; set; }
+        public bool IsPrimaryMatchday { get; set; }
+    }
+}

--- a/FixtureScheduler/Models/Settings.cs
+++ b/FixtureScheduler/Models/Settings.cs
@@ -6,12 +6,13 @@ namespace Models
 		public DateTime EndDate { get; set; }
 		public DayOfWeek PrimaryMatchDay { get; set; }
 		public DayOfWeek AlternativeMatchday { get; set; }
+		public int NumberOfRoundsNeeded { get; set; }
 		public List<ExcludedDates> ExcludedDates { get; set; } = new List<ExcludedDates>();
 	}
 
 	public class ExcludedDates
 	{
 		public DateTime Date { get; set; }
-		public string Reason { get; set; }
+		public string Reason { get; set; } = string.Empty;
 	}
 }

--- a/FixtureScheduler/Models/Settings.cs
+++ b/FixtureScheduler/Models/Settings.cs
@@ -6,5 +6,12 @@ namespace Models
 		public DateTime EndDate { get; set; }
 		public DayOfWeek PrimaryMatchDay { get; set; }
 		public DayOfWeek AlternativeMatchday { get; set; }
+		public List<ExcludedDates> ExcludedDates { get; set; } = new List<ExcludedDates>();
+	}
+
+	public class ExcludedDates
+	{
+		public DateTime Date { get; set; }
+		public string Reason { get; set; }
 	}
 }

--- a/FixtureScheduler/Models/Teams.cs
+++ b/FixtureScheduler/Models/Teams.cs
@@ -1,0 +1,7 @@
+namespace Models
+{
+    public class Teams
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+}

--- a/FixtureScheduler/Program.cs
+++ b/FixtureScheduler/Program.cs
@@ -1,24 +1,28 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using BusinessLogic;
+using Microsoft.Extensions.DependencyInjection;
 
-//Loads the settings
-var settings = BusinessLogic.ApplicationSettings.LoadSettings();
+List<Models.Teams> teams;
 
-if (settings == null)
+try
 {
+    //Loads the teams from the teams json files
+    teams = BusinessLogic.Teams.LoadTeams();
+}
+catch (FixtureSchedulerException ex)
+{
+    //Exits if the 
+    Console.WriteLine(ex.Message);
+    Environment.Exit(1);
+
+    //This return will never be reached but seems to be required to keep the compiler happy :)
     return;
 }
 
-//Defines the number of teams
-var totalNumberOfTeams = 24;
-
-//Sets the number of rounds needed to play all the games
-//This is (Number of Teams x 2 - 2)
-var numberOfRoundsNeeded = (totalNumberOfTeams - 1) * 2;
-
 //Sets up the dependency injection and registers interfaces and their implementation classes
-//Also passes in the settings created earlier so these can be used elsewhere in the application
+//Also passes in the teams created earlier so these can be used elsewhere in the application
 var serviceProvider = new ServiceCollection()
-    .AddSingleton(settings)
+    .AddSingleton(teams)
+    .AddSingleton<Interfaces.IApplicationSettings, BusinessLogic.ApplicationSettings>()
     .AddSingleton<Interfaces.IBankHolidays, BusinessLogic.BankHolidays>()
     .AddSingleton<Interfaces.IDates, BusinessLogic.Dates>()
     .BuildServiceProvider();
@@ -29,12 +33,12 @@ var dates = serviceProvider.GetRequiredService<Interfaces.IDates>();
 var availableDates = dates.GetAvailableDates().OrderBy(x => x.Date);
 
 //Counts the number of primary matchdays
-var numberOfPrimaryMatchdays = dates.CountMatchdays(useAlternativeMatchday: false);
+//var numberOfPrimaryMatchdays = dates.CountMatchdays(useAlternativeMatchday: false);
 
-if (numberOfPrimaryMatchdays < numberOfRoundsNeeded)
-{
-    Console.WriteLine("Not enough primary matchdays");
-}
+//if (numberOfPrimaryMatchdays < numberOfRoundsNeeded)
+//{
+//    Console.WriteLine("Not enough primary matchdays");
+//}
 
 //Counts the number of saturdays between the two dates
 int count = dates.CountMatchdays(useAlternativeMatchday: false);

--- a/FixtureScheduler/Program.cs
+++ b/FixtureScheduler/Program.cs
@@ -27,27 +27,31 @@ var serviceProvider = new ServiceCollection()
     .AddSingleton<Interfaces.IDates, BusinessLogic.Dates>()
     .BuildServiceProvider();
 
-//Creates an instance of dates
-var dates = serviceProvider.GetRequiredService<Interfaces.IDates>();
+try
+{
+    //Resolve IApplicationSettings now — this will run the constructor and load settings
+    var applicationSettings = serviceProvider.GetRequiredService<Interfaces.IApplicationSettings>();
 
-var availableDates = dates.GetAvailableDates().OrderBy(x => x.Date);
+    //Creates an instance of dates
+    var dates = serviceProvider.GetRequiredService<Interfaces.IDates>();
 
-//Counts the number of primary matchdays
-//var numberOfPrimaryMatchdays = dates.CountMatchdays(useAlternativeMatchday: false);
+    //Gets the available
+    var availableDates = dates.GetAvailableDates().OrderBy(x => x.Date);
 
-//if (numberOfPrimaryMatchdays < numberOfRoundsNeeded)
-//{
-//    Console.WriteLine("Not enough primary matchdays");
-//}
+    //Counts the number of saturdays between the two dates
+    int count = dates.CountMatchdays(useAlternativeMatchday: false);
 
-//Counts the number of saturdays between the two dates
-int count = dates.CountMatchdays(useAlternativeMatchday: false);
+    //This will get removed at some point
+    Console.WriteLine("Hello, World!");
+    Console.WriteLine(count.ToString());
 
-//This will get removed at some point
-Console.WriteLine("Hello, World!");
-Console.WriteLine(count.ToString());
+    var y = Console.ReadLine();
 
-var y = Console.ReadLine();
-
-Console.WriteLine(y);
-Console.Read();
+    Console.WriteLine(y);
+    Console.Read();
+}
+catch (FixtureSchedulerException ex)
+{
+    Console.WriteLine(ex.Message);
+    Environment.Exit(1);
+}

--- a/FixtureScheduler/Program.cs
+++ b/FixtureScheduler/Program.cs
@@ -26,6 +26,7 @@ var serviceProvider = new ServiceCollection()
 //Creates an instance of dates
 var dates = serviceProvider.GetRequiredService<Interfaces.IDates>();
 
+var availableDates = dates.GetAvailableDates().OrderBy(x => x.Date);
 
 //Counts the number of primary matchdays
 var numberOfPrimaryMatchdays = dates.CountMatchdays(useAlternativeMatchday: false);

--- a/FixtureScheduler/Settings/Settings.json
+++ b/FixtureScheduler/Settings/Settings.json
@@ -1,7 +1,7 @@
 {
   "Settings": {
-    "StartDate": "01/08/2025",
-    "EndDate": "01/05/2026",
+    "StartDate": "09/08/2025",
+    "EndDate": "25/04/2026",
     "ExcludedDates": [
       {
         "Date": "13/09/2025",
@@ -20,8 +20,16 @@
         "Reason": "FA Trophy 3rd Round"
       },
       {
+        "Date": "24/12/2025",
+        "Reason": "Christmas Eve"
+      },
+      {
         "Date": "25/12/2025",
         "Reason": "Christmas Day"
+      },
+      {
+        "Date": "01/01/2026",
+        "Reason": "New Years Day"
       }
     ],
     "PrimaryMatchday": "Saturday",

--- a/FixtureScheduler/Settings/Settings.json
+++ b/FixtureScheduler/Settings/Settings.json
@@ -2,6 +2,28 @@
   "Settings": {
     "StartDate": "01/08/2025",
     "EndDate": "01/05/2026",
+    "ExcludedDates": [
+      {
+        "Date": "13/09/2025",
+        "Reason": "FA Cup 2nd Qualifying Round"
+      },
+      {
+        "Date": "27/09/2025",
+        "Reason": "FA Cup 3rd Qualifying Round"
+      },
+      {
+        "Date": "15/11/2025",
+        "Reason": "FA Trophy 2nd Round"
+      },
+      {
+        "Date": "13/12/2025",
+        "Reason": "FA Trophy 3rd Round"
+      },
+      {
+        "Date": "25/12/2025",
+        "Reason": "Christmas Day"
+      }
+    ],
     "PrimaryMatchday": "Saturday",
     "AlternativeMatchday": "Tuesday"
   }

--- a/FixtureScheduler/Settings/Teams.json
+++ b/FixtureScheduler/Settings/Teams.json
@@ -1,0 +1,76 @@
+{
+    "Teams": [
+        {
+            "Name": "Team 1"
+        },
+        {
+            "Name": "Team 2"
+        },
+        {
+            "Name": "Team 3"
+        },
+        {
+            "Name": "Team 4"
+        },
+        {
+            "Name": "Team 5"
+        },
+        {
+            "Name": "Team 6"
+        },
+        {
+            "Name": "Team 7"
+        },
+        {
+            "Name": "Team 8"
+        },
+        {
+            "Name": "Team 9"
+        },
+        {
+            "Name": "Team 10"
+        },
+        {
+            "Name": "Team 11"
+        },
+        {
+            "Name": "Team 12"
+        },
+        {
+            "Name": "Team 13"
+        },
+        {
+            "Name": "Team 14"
+        },
+        {
+            "Name": "Team 15"
+        },
+        {
+            "Name": "Team 16"
+        },
+        {
+            "Name": "Team 17"
+        },
+        {
+            "Name": "Team 18"
+        },
+        {
+            "Name": "Team 19"
+        },
+        {
+            "Name": "Team 20"
+        },
+        {
+            "Name": "Team 21"
+        },
+        {
+            "Name": "Team 22"
+        },
+        {
+            "Name": "Team 23"
+        },
+        {
+            "Name": "Team 24"
+        }
+    ]
+}

--- a/FixtureScheduler/Validation/ApplicationSettingsValidation.cs
+++ b/FixtureScheduler/Validation/ApplicationSettingsValidation.cs
@@ -10,32 +10,21 @@ namespace Validation
         {
             RuleFor(x => x.StartDate)
                 .NotEmpty().WithMessage("Start date is required")
-                .Must(BeValidDate).WithMessage("Start date is not a valid date");
+                .Must(ValidationHelpers.BeValidDate).WithMessage("Start date is not a valid date");
 
             RuleFor(x => x.EndDate)
                 .NotEmpty().WithMessage("End date is required")
-                .Must(BeValidDate).WithMessage("End date is not a valid date");
+                .Must(ValidationHelpers.BeValidDate).WithMessage("End date is not a valid date");
 
             RuleFor(x => x.PrimaryMatchday)
                 .NotEmpty().WithMessage("Primary matchday is requird")
-                .Must(BeValidDay).WithMessage("Primary matchday is not a valid day");
+                .Must(ValidationHelpers.BeValidDay).WithMessage("Primary matchday is not a valid day");
 
             RuleFor(x => x.AlternativeMatchday)
                 .NotEmpty().WithMessage("Alternative matchday is requird")
-                .Must(BeValidDay).WithMessage("Alternative matchday is not a valid day");
-        }
+                .Must(ValidationHelpers.BeValidDay).WithMessage("Alternative matchday is not a valid day");
 
-        private bool BeValidDate(string date)
-        {
-            return DateTime.TryParseExact(date, "dd/MM/yyyy", CultureInfo.InvariantCulture, DateTimeStyles.None, out _);
-        }
-
-        private bool BeValidDay(string day)
-        {
-            //Returns true if the supplied string matches any of the values below
-            //Otherwise returns false
-            string[] validDays = { "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday" };
-            return validDays.Contains(day);
+            RuleForEach(x => x.ExcludedDates).SetValidator(new ExcludedDatesValidation());
         }
     }
 }

--- a/FixtureScheduler/Validation/ExcludedDatesValidation.cs
+++ b/FixtureScheduler/Validation/ExcludedDatesValidation.cs
@@ -1,0 +1,17 @@
+using FluentValidation;
+
+namespace Validation
+{
+    public class ExcludedDatesValidation : AbstractValidator<DTOs.ExcludedDatesDTO>
+    {
+        public ExcludedDatesValidation()
+        {
+            RuleFor(x => x.Date)
+                .NotEmpty().WithMessage("Date is required")
+                .Must(ValidationHelpers.BeValidDate).WithMessage("Date is not valid");
+
+            RuleFor(x => x.Reason)
+                .NotEmpty().WithMessage("Reason is required");
+        }
+    }
+}

--- a/FixtureScheduler/Validation/TeamsValidation.cs
+++ b/FixtureScheduler/Validation/TeamsValidation.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+
+namespace Validation
+{
+    public class TeamsValidation : AbstractValidator<DTOs.TeamsDTO>
+    {
+        public TeamsValidation()
+        {
+            RuleFor(x => x.Name)
+                .NotEmpty().WithMessage("Team name is required");
+        }
+    }
+}

--- a/FixtureScheduler/Validation/ValidationHelpers.cs
+++ b/FixtureScheduler/Validation/ValidationHelpers.cs
@@ -1,0 +1,30 @@
+using System.Globalization;
+
+namespace Validation
+{
+    public class ValidationHelpers()
+    {
+        /// <summary>
+        /// Ensures a string is a valid date in uk format
+        /// </summary>
+        /// <param name="date"></param>
+        /// <returns></returns>
+        public static bool BeValidDate(string date)
+        {
+            return DateTime.TryParseExact(date, "dd/MM/yyyy", CultureInfo.InvariantCulture, DateTimeStyles.None, out _);
+        }
+
+        /// <summary>
+        /// Ensures a string is a valid day of the week
+        /// </summary>
+        /// <param name="day"></param>
+        /// <returns></returns>
+        public static bool BeValidDay(string day)
+        {
+            //Returns true if the supplied string matches any of the values below
+            //Otherwise returns false
+            string[] validDays = { "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday" };
+            return validDays.Contains(day);
+        }
+    }
+}


### PR DESCRIPTION
Tidied up ApplicationSettings.cs. Also added Teams.cs so that teams can be read in from the Teams.json file. These values are then used by the application settings.

Dates.cs class has been updated so that it returns a list of available dates. This will first use bank holidays first. It will then use two provided dates to create a list of available dates for primary match days. Development will need to be continued to see if more dates are needed and then use alternative match days to fill in the gaps.